### PR TITLE
Alternative annotation format for dependency tagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This git repository contains [ELG compatible](https://european-language-grid.rea
 
 [lt_core_news_lg](https://spacy.io/models/lt#lt_core_news_lg) is a large Lithuanian pipeline trained on written web text (blogs, news, comments), that includes vocabulary, syntax and entities. It has a large word vector table with 500000 keys and 500000 unique vectors (300 dimensions). The model was developed based on the following datasets: [UD Lithuanian ALKSNIS v2.8](https://github.com/UniversalDependencies/UD_Lithuanian-ALKSNIS), [TokenMill NER Corpus](https://www.tokenmill.lt/), [Explosion fastText Vectors (cbow, OSCAR Common Crawl + Wikipedia)](https://spacy.io/). The library is published under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license and its main developers are Matthew Honnibal and Ines Montani, the founders of the software company [Explosion](https://explosion.ai/).
 
-You can call two endpoints: `tagger` and `ner`. `tagger` groups tokens by their [pos](https://spacy.io/api/morphologizer) tag and also shows their starting and ending indexes, [lemma](https://spacy.io/api/lemmatizer), [dep](https://spacy.io/api/dependencyparser), [morph](https://spacy.io/api/morphologizer), [tag](https://spacy.io/api/tagger), [head](https://spacy.io/api/dependencyparser). `ner` groups entities (that can contain more than 1 token) by their [label](https://spacy.io/usage/linguistic-features#named-entities) tag and shows their starting and ending indexes.
+You can call two endpoints: `tagger` and `ner`. `tagger` produces annotations `token` and `sentence`, and each token includes features with the [pos](https://spacy.io/api/morphologizer) tag, [lemma](https://spacy.io/api/lemmatizer), [dep](https://spacy.io/api/dependencyparser), [morph](https://spacy.io/api/morphologizer), [tag](https://spacy.io/api/tagger), and [head](https://spacy.io/api/dependencyparser) link in the dependency tree. `ner` groups entities (that can contain more than 1 token) by their [label](https://spacy.io/usage/linguistic-features#named-entities) tag and shows their starting and ending indexes.
 
 This ELG API was developed in EU's CEF project [Microservices at your service](https://www.lingsoft.fi/en/microservices-at-your-service-bridging-gap-between-nlp-research-and-industry).
 
@@ -69,11 +69,19 @@ Tagger
   "response": {
     "type": "annotations",
     "annotations": {
-      "PROPN": [
+      "sentence": [
+        {
+          "start": 0,
+          "end": 24,
+          "features": {}
+        }
+      ],
+      "token": [
         {
           "start": 0,
           "end": 7,
           "features": {
+            "pos": "PROPN",
             "lemma": "Filipas",
             "dep": "nsubj",
             "morph": "Case=Nom|Gender=Masc|Number=Sing",
@@ -82,35 +90,34 @@ Tagger
           }
         },
         {
-          "start": 15,
-          "end": 23,
-          "features": {
-            "lemma": "Vilnius",
-            "dep": "obl",
-            "morph": "Case=Loc|Gender=Masc|Number=Sing",
-            "tag": "dkt.tikr.vyr.vns.Vt.",
-            "head": "gyvena"
-          }
-        }
-      ],
-      "VERB": [
-        {
           "start": 8,
           "end": 14,
           "features": {
+            "pos": "VERB",
             "lemma": "gyventi",
             "dep": "ROOT",
             "morph": "Mood=Ind|Number=Sing|Person=3|Polarity=Pos|Tense=Pres|VerbForm=Fin",
             "tag": "vksm.asm.tiesiog.es.vns.3.",
             "head": "gyvena"
           }
-        }
-      ],
-      "PUNCT": [
+        },
+        {
+          "start": 15,
+          "end": 23,
+          "features": {
+            "pos": "PROPN",
+            "lemma": "Vilnius",
+            "dep": "obl",
+            "morph": "Case=Loc|Gender=Masc|Number=Sing",
+            "tag": "dkt.tikr.vyr.vns.Vt.",
+            "head": "gyvena"
+          }
+        },
         {
           "start": 23,
           "end": 24,
           "features": {
+            "pos": "PUNCT",
             "lemma": ".",
             "dep": "punct",
             "morph": "",
@@ -164,10 +171,10 @@ Tagger
   - morphological features
 - [tag](https://spacy.io/api/tagger)
   - part of speech
+- id
+  - unique identifier of this token
 - [head](https://spacy.io/api/dependencyparser)
-  - syntactic parent, or “governor”, of this token
-
- [label](https://spacy.io/usage/linguistic-features#named-entities) tag and shows their starting and ending indexes.
+  - syntactic parent, or “governor”, of this token, expressed as a link to the head token's `id`
 
 NER
 - `start` and `end` (int)

--- a/app.py
+++ b/app.py
@@ -16,32 +16,38 @@ class SpaCyLt(FlaskService):
         annotations = {}
         offset = 0
         if endpoint == "tagger":
-            for token in outputs:
-                pos = token.pos_
-                if pos != "SPACE":
-                    word = token.text
-                    lemma = token.lemma_
-                    dep = token.dep_
-                    morph = token.morph
-                    tag = token.tag_
-                    head = token.head
+            for sent in outputs.sents:
+                annotations.setdefault("sentence", []).append({
+                    "start": sent.start_char,
+                    "end": sent.end_char,
+                    "features": {},
+                })
+                for token in sent:
+                    pos = token.pos_
+                    if pos != "SPACE":
+                        word = token.text
+                        lemma = token.lemma_
+                        dep = token.dep_
+                        morph = token.morph
+                        tag = token.tag_
+                        head = token.head
 
-                    start = content.find(word) + offset
-                    end = start + len(word)
-                    content = content[end - offset:]
-                    offset = end
-                    annot = {
-                        "start": start,
-                        "end": end,
-                        "features": {
-                            "lemma": str(lemma),
-                            "dep": str(dep),
-                            "morph": str(morph),
-                            "tag": str(tag),
-                            "head": str(head)
+                        start = token.idx
+                        end = start + len(word)
+                        annot = {
+                            "start": start,
+                            "end": end,
+                            "features": {
+                                "id": f"w{token.i}",
+                                "lemma": str(lemma),
+                                "dep": str(dep),
+                                "morph": str(morph),
+                                "tag": str(tag),
+                                "pos": str(pos),
+                                "head": f"w{head.i}" if head and head.i != token.i else None,
+                                }
                             }
-                        }
-                    annotations.setdefault(pos, []).append(annot)
+                        annotations.setdefault( "token", []).append(annot)
         elif endpoint == "ner":
             for ent in outputs.ents:
                 start = ent.start_char

--- a/elg_local_tagger/nginx-conf/html/index.html.template
+++ b/elg_local_tagger/nginx-conf/html/index.html.template
@@ -54,7 +54,7 @@
     }
   }, false);
 
-  iframe.src = '/egistry_gitlab_com_european_language_grid_usfd_gui_ie_latest/';
+  iframe.src = '/egistry_gitlab_com_european_language_grid_usfd_gui_ie_latest/index-dependency.html?token=token&sentence=sentence&id=id&parent=head&label=text&label=00008b;dep&label=004048;pos';
 })();
 
 </script>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,7 +38,8 @@ class TestTaggerIntegration(unittest.TestCase):
     def test_tagger_response_content(self):
         response = call_api(self.endpoint, self.text)
         for entity in ("PROPN", "VERB", "PUNCT"):
-            self.assertIn(entity, response["response"]["annotations"])
+            self.assertIn(entity, [t["features"]["pos"] for t in response["response"]["annotations"]["token"]])
+        self.assertIn("sentence", response["response"]["annotations"])
 
     def test_tagger_with_empty_request(self):
         response = call_api(self.endpoint, "")
@@ -58,7 +59,7 @@ class TestTaggerIntegration(unittest.TestCase):
     def test_tagger_with_special_characters(self):
         spec_text = "\N{grinning face}\u4e01\u0009" + self.text + "\u0008"
         response = call_api(self.endpoint, spec_text)
-        gpe = response["response"]["annotations"]["PROPN"][1]
+        gpe = [t for t in response["response"]["annotations"]["token"] if t["features"]["pos"] == "PROPN"][1]
         self.assertEqual(spec_text[gpe["start"]:gpe["end"]], "Vilniuje")
 
 


### PR DESCRIPTION
I've been discussing this submission with @galanisd, and this PR is to suggest a possible alternative format for your annotations that makes the dependency relations unambiguous, allowing them to be rendered as parse trees:

- instead of one annotation type per POS tag, use a single `token` annotation type, with the POS tag as a _feature_
- also add `sentence` annotations showing how the tokens group into sentences
- give each token a unique identifier
- rather than using the _text_ of the governor token as the `head` feature, we can now use the head token's unique ID

Linking by ID means there can be no ambiguity if the same word is used more than once in the same sentence, making it possible to unambiguously reconstruct the dependency tree.  I've updated the local compose stack to show how this works with the standard ELG dependency tree viewer GUI.